### PR TITLE
Detect the situation where the user has not entered a PIN

### DIFF
--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -148,6 +148,27 @@ void OpenSCToken::verifyPIN(int pinNum, const uint8_t *pin, size_t pinLength)
 {
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::verifyPIN(%d)\n", pinNum);
 	int pNumber = pinNum;
+
+        // If the user entered no PIN in the (OS) provided prompt; pinLength is
+        // zero; but *pin points to the empty string; rather than being NULL.
+        //
+        // In the specific case that there is a PIN pad reader connected we
+        // detect this; and used it to trigger a read of the PIN on the
+        // PIN pad (which requires both pin == NULL and pinLength == 0).
+        //
+        if (mScP15Card->card->reader->capabilities & SC_READER_CAP_PIN_PAD) {
+               if (pinLength == 0) {
+                       sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "Defer PIN entry to the reader keypad.");
+                       pin = NULL;
+               } else {
+                       // We are not blocking key entry from the keyboard. As it is too late at
+                       // this point - the user has already entered the PIN on the desktop its
+                       // its keyboard. Longer term we could start honouring the flag
+                       // CSSM_ACL_SUBJECT_TYPE_PROTECTED_PASSWORD.
+                       //
+                       sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "Warning: the reader keypad is not used; PIN entered on keyboard.");
+               }
+        };
 	
 	if (mCurrentPIN != -1) {
 		pNumber = mCurrentPIN;


### PR DESCRIPTION
at all -and- we have a reader with its own PIN pad connected
(e.g. a SPR532, ParityMedical, eH880, etc).

In that case; defer entry to the reader.

We do not, however, prevent the user from entering the
PIN on the normal keyboard. As we're 'too late' already. If
the user has already done that; we simply pass on the
entered value.