### PR TITLE
Improves support for PIV tokens, adds SHA-2 and ECDSA

### DIFF
--- a/OpenSC/OpenSCAttributeCoder.cpp
+++ b/OpenSC/OpenSCAttributeCoder.cpp
@@ -72,11 +72,30 @@ Tokend::Record &record)
 		case kSecKeyKeySizeInBits:
 			if(keyObj->type & SC_PKCS15_TYPE_PRKEY) {
 				sc_pkcs15_prkey_info *prkey = (sc_pkcs15_prkey_info *)keyObj->data;
-				value = prkey->modulus_length;
+				if (keyObj->type == SC_PKCS15_TYPE_PRKEY_EC)
+					value = prkey->field_length; /* EC field length in bits */
+				else
+					value = prkey->modulus_length; /* RSA modulus length in bits */
+				// FIXME - need to address DSA keys too
 			}
 			else if(keyObj->type & SC_PKCS15_TYPE_PUBKEY) {
 				sc_pkcs15_pubkey_info *pubkey = (sc_pkcs15_pubkey_info *)keyObj->data;
-				value = pubkey->modulus_length;
+				if (keyObj->type == SC_PKCS15_TYPE_PRKEY_EC)
+					value = pubkey->field_length; /* EC field length in bits */
+				else
+					value = pubkey->modulus_length; /* RSA modulus length in bits */
+				// FIXME - need to address DSA keys too
+			}
+			else if(keyObj->type & SC_PKCS15_TYPE_PUBKEY) {
+				sc_pkcs15_pubkey_info *pubkey = (sc_pkcs15_pubkey_info *)keyObj->data;
+				if (keyObj->type == SC_PKCS15_TYPE_PRKEY_EC) {
+				  sc_debug(token_obj.mScCtx, SC_LOG_DEBUG_NORMAL, "keyObj type EC (%d)\n", keyObj->type);
+					value = pubkey->field_length; /* EC field length in bits */
+				} else {
+				  sc_debug(token_obj.mScCtx, SC_LOG_DEBUG_NORMAL, "keyObj type RSA (%d)\n", keyObj->type);
+					value = pubkey->modulus_length; /* RSA modulus length in bits */
+				}
+				// FIXME - need to address DSA keys too
 			}
 			else {
 				sc_debug(token_obj.mScCtx, SC_LOG_DEBUG_NORMAL, "Unknown keyObj type: %d\n", keyObj->type);

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -160,7 +160,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	if (padding == CSSM_PADDING_PKCS1) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  PKCS#1 padding\n");
-		//flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
 	}
 	else if (padding == CSSM_PADDING_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO padding\n");

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -261,26 +261,63 @@ const CssmData &cipher, CssmData &clear)
 	if (context.type() != CSSM_ALGCLASS_ASYMMETRIC)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_CONTEXT);
 
-	if (context.algorithm() != CSSM_ALGID_RSA)
+	if ((context.algorithm() != CSSM_ALGID_RSA) &&
+            (context.algorithm() != CSSM_ALGID_ECDH))
 		CssmError::throwMe(CSSMERR_CSP_INVALID_ALGORITHM);
 
 	// @@@ Switch to using tokend allocators
-	unsigned char *outputData =
+        unsigned char *outputData = NULL;
 		reinterpret_cast<unsigned char *>(malloc(cipher.Length));
-	if (outputData == NULL)
-		CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
-
+	
 	// Call OpenSC to do the actual decryption
-	int rv = sc_pkcs15_decipher(mToken.mScP15Card,
-		mKey.decryptKey(), SC_ALGORITHM_RSA_PAD_PKCS1,
-		cipher.Data, cipher.Length, outputData, cipher.Length);
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_decipher(): rv = %d\n", rv);
-	if (rv < 0) {
-		free(outputData);
-		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
-	}
-	clear.Data = outputData;
-	clear.Length = rv;
+        int rv = -1; // return code
+        unsigned long output_len = 0; // needed for ECDH
+        
+        if (context.algorithm() == CSSM_ALGID_RSA) {
+                // RSA decryption
+                outputData =
+                	reinterpret_cast<unsigned char *>(malloc(cipher.Length));
+                if (outputData == NULL)
+                        CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
+		rv = sc_pkcs15_decipher(mToken.mScP15Card,
+			mKey.decryptKey(), SC_ALGORITHM_RSA_PAD_PKCS1,
+			cipher.Data, cipher.Length, outputData, cipher.Length);
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  sc_pkcs15_decipher(): rv = %d\n", rv);
+		if (rv < 0) {
+			free(outputData);
+			CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
+		}
+		clear.Data = outputData;
+		clear.Length = rv;
+        }
+        else {
+                // ECDH key derivation
+                // First get length of the derived key
+                rv = sc_pkcs15_derive(mToken.mScP15Card,
+	                        mKey.decryptKey(), SC_ALGORITHM_ECDH_CDH_RAW,
+                                cipher.Data, cipher.Length, NULL, &output_len);
+                sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  sc_pkcs15_derive() told us to allocate %d bytes\n",
+                         output_len);
+                outputData =
+	                reinterpret_cast<unsigned char *>(malloc(output_len));
+                if (outputData == NULL)
+                        CssmError::throwMe(CSSMERR_CSP_MEMORY_ERROR);
+
+                rv = sc_pkcs15_derive(mToken.mScP15Card,
+                        mKey.decryptKey(), SC_ALGORITHM_ECDH_CDH_RAW,
+                        cipher.Data, cipher.Length, outputData, &output_len);
+                sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  sc_pkcs15_derive(): rv = %d\n", rv);
+                if (rv < 0) {
+                        free(outputData);
+                        CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
+                }
+                clear.Data = outputData;
+                clear.Length = output_len;
+
+        }
 
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  decrypt(): returning with %d decrypted bytes%d\n", clear.Length);
 }

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -155,7 +155,11 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 	// Get padding, but default to pkcs1 style padding for RSA
 	uint32 padding = context.getInt(CSSM_ATTRIBUTE_PADDING);
 	if (context.algorithm() == CSSM_ALGID_RSA) {
-		padding = CSSM_PADDING_PKCS1;
+		if (signOnly == CSSM_ALGID_NONE)
+			// For SSL authentication padding must be NONE
+			padding = CSSM_PADDING_NONE;
+		else
+			padding = CSSM_PADDING_PKCS1;
 	}
 	else if (context.algorithm() == CSSM_ALGID_ECDSA) {
 		padding = CSSM_PADDING_NONE;

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -160,7 +160,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	if (padding == CSSM_PADDING_PKCS1) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  PKCS#1 padding\n");
-		flags |= SC_ALGORITHM_RSA_PAD_PKCS1; // hopefully not needed now
+		flags |= SC_ALGORITHM_RSA_PAD_PKCS1;
 	}
 	else if (padding == CSSM_PADDING_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO padding\n");
@@ -191,9 +191,13 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		CssmError::throwMe(CSSMERR_CSP_FUNCTION_FAILED);
 	}
 
-	if (mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_EC)
+	if (mKey.signKey()->type == SC_PKCS15_TYPE_PRKEY_RSA)
 	{
-		// Wrap the result of compute_signature() as ASN.1 SEQUENCE
+                // For RSA just pass along the return of sc_pkcs15_compute_signature()
+                signature.Data = outputData;
+                signature.Length = rv;
+        } else {
+		// For ECDSA wrap the result of compute_signature() as ASN.1 SEQUENCE
 		unsigned char *seq;
 		size_t seqlen;
 		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx, outputData, sig_len, &seq, &seqlen))   {
@@ -212,10 +216,6 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
 				"  Converted ECDSA signature to ASN.1 SEQUENCE: seqlen=%d\n",
 				seqlen);
-	} else {
-		// For RSA just pass along the return of sc_pkcs15_compute_signature()
-		signature.Data = outputData;
-		signature.Length = rv;
 	}
 }
 

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -30,6 +30,7 @@
 #include <security_utilities/utilities.h>
 #include <security_cdsa_utilities/cssmerrors.h>
 #include <Security/cssmerr.h>
+#include <Security/cssmapple.h>
 
 #include "libopensc/log.h"
 /************************** OpenSCKeyHandle ************************/
@@ -95,14 +96,31 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		if (input.Length != 20)
 			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
 		flags |= SC_ALGORITHM_RSA_HASH_SHA1;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA1, length is 20\n");
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA1, length is 20 bytes\n");
 	}
 	else if (signOnly == CSSM_ALGID_MD5) {
 		if (input.Length != 16)
 			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
 		flags |= SC_ALGORITHM_RSA_HASH_MD5;
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using MD5, length is 16\n");
-
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using MD5, length is 16 bytes\n");
+	}
+   	else if (signOnly == CSSM_ALGID_SHA256) {
+		if (input.Length != 32)
+			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+		flags |= SC_ALGORITHM_RSA_HASH_SHA256;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA256, length is 32 bytes\n");
+	}
+   	else if (signOnly == CSSM_ALGID_SHA384) {
+		if (input.Length != 48)
+			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+		flags |= SC_ALGORITHM_RSA_HASH_SHA384;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA384, length is 48 bytes\n");
+	}
+   	else if (signOnly == CSSM_ALGID_SHA512) {
+		if (input.Length != 64)
+			CssmError::throwMe(CSSMERR_CSP_BLOCK_SIZE_MISMATCH);
+		flags |= SC_ALGORITHM_RSA_HASH_SHA512;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Using SHA512, length is 64 bytes\n");
 	}
 	else if (signOnly == CSSM_ALGID_NONE) {
 		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  NO digest (perhaps for SSL authentication)\n");

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -131,7 +131,8 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		flags |= SC_ALGORITHM_RSA_HASH_NONE;
 	}
 	else {
-		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                         "  Unknown signOnly value: 0x%0x, exiting\n", signOnly);
 		CssmError::throwMe(CSSMERR_CSP_INVALID_DIGEST_ALGORITHM);
 	}
 
@@ -186,6 +187,7 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
 		"  Signing buffers: inlen=%d, outlen=%d\n",input.Length, sig_len);
+        
 	// Call OpenSC to do the actual signing (RSA or ECDSA)
 	int rv = sc_pkcs15_compute_signature(mToken.mScP15Card,
 					     mKey.signKey(), flags,
@@ -207,7 +209,10 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
 		// For ECDSA wrap the result of compute_signature() as ASN.1 SEQUENCE
 		unsigned char *seq;
 		size_t seqlen;
-		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx, outputData, sig_len, &seq, &seqlen))   {
+		if (sc_asn1_sig_value_rs_to_sequence(mToken.mScCtx,
+                                                     outputData, sig_len,
+                                                     &seq, &seqlen))
+                {
 			sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
 				"Failed to convert signature to ASN1 sequence format.\n");
 			free(outputData);
@@ -263,7 +268,8 @@ void OpenSCKeyHandle::decrypt(const Context &context,
 const CssmData &cipher, CssmData &clear)
 {
 	secdebug("crypto", "decrypt alg: %lu", (long unsigned int) context.algorithm());
-	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCKeyHandle::decrypt(ciphertext length = %d)\n", cipher.Length);
+	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+                 "In OpenSCKeyHandle::decrypt(ciphertext length = %d)\n", cipher.Length);
 	
 	if (context.type() != CSSM_ALGCLASS_ASYMMETRIC)
 		CssmError::throwMe(CSSMERR_CSP_INVALID_CONTEXT);
@@ -284,8 +290,8 @@ const CssmData &cipher, CssmData &clear)
 
 	// Determine padding
 	unsigned int flags = 0;
-	unsigned int padding = 0;
-	padding = context.getInt(CSSM_ATTRIBUTE_PADDING, CSSMERR_CSP_INVALID_ATTR_PADDING);
+	unsigned int padding = context.getInt(CSSM_ATTRIBUTE_PADDING,
+                                              CSSMERR_CSP_INVALID_ATTR_PADDING);
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "   got padding=%d 0x%X\n",
 		 padding, padding);
 	if (padding == CSSM_PADDING_PKCS1)

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -205,6 +205,8 @@ CSSM_ALGORITHMS signOnly, const CssmData &input, CssmData &signature)
                 // For RSA just pass along the return of sc_pkcs15_compute_signature()
                 signature.Data = outputData;
                 signature.Length = rv;
+		sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL,
+			"  Completed RSA signature, len=%d\n", rv);
         } else {
 		// For ECDSA wrap the result of compute_signature() as ASN.1 SEQUENCE
 		unsigned char *seq;

--- a/OpenSC/OpenSCKeyHandle.cpp
+++ b/OpenSC/OpenSCKeyHandle.cpp
@@ -283,12 +283,14 @@ const CssmData &cipher, CssmData &clear)
 	}
 
 	// @@@ Switch to using tokend allocators
+	unsigned char *outputData = NULL;
+	
 	// Allocation will be done later, as amount would differ,
 	// depending on whether it is RSA or ECDH
 
 	// Determine padding
 	unsigned int flags = 0;
-	uint32 int padding = context.getInt(CSSM_ATTRIBUTE_PADDING,
+	uint32 padding = context.getInt(CSSM_ATTRIBUTE_PADDING,
 					    CSSMERR_CSP_INVALID_ATTR_PADDING);
 	sc_debug(mToken.mScCtx, SC_LOG_DEBUG_NORMAL, "   got padding=%d 0x%X\n",
 		 padding, padding);

--- a/OpenSC/OpenSCRecord.cpp
+++ b/OpenSC/OpenSCRecord.cpp
@@ -98,7 +98,11 @@ void OpenSCCertificateRecord::getAcl(const char *tag, uint32 &count, AclEntryInf
 size_t OpenSCKeyRecord::sizeInBits() const
 {
 	sc_pkcs15_prkey_info *prkey = (sc_pkcs15_prkey_info *)mPrKeyObj->data;
-	return prkey->modulus_length;
+	if (mPrKeyObj->type == SC_PKCS15_TYPE_PRKEY_EC)
+		return prkey->field_length; /* EC field length in bits */
+	else
+		return prkey->modulus_length; /* RSA modulus length in bits */
+	// FIXME - need to address DSA keys too
 }
 
 /************************** OpenSCKeyRecord *****************************/

--- a/OpenSC/OpenSCSchema.cpp
+++ b/OpenSC/OpenSCSchema.cpp
@@ -42,8 +42,8 @@
 
 using namespace Tokend;
 
-OpenSCSchema::OpenSCSchema() :
-mKeyAlgorithmCoder(uint32(CSSM_ALGID_RSA)),
+OpenSCSchema::OpenSCSchema(bool use_ecc) :
+mKeyAlgorithmCoder(uint32((use_ecc)?CSSM_ALGID_ECC:CSSM_ALGID_RSA)),
 mKeyAttributeCoder()
 {
 }

--- a/OpenSC/OpenSCSchema.h
+++ b/OpenSC/OpenSCSchema.h
@@ -52,7 +52,7 @@ class OpenSCSchema : public Tokend::Schema
 {
 	NOCOPY(OpenSCSchema)
 		public:
-		OpenSCSchema();
+		OpenSCSchema(bool use_ecc = false);
 		virtual ~OpenSCSchema();
 
 		virtual void create();

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -466,7 +466,6 @@ void OpenSCToken::populate()
 	KeyCountMap mKeys;
 	
 	// Locate certificates
-	//FIXME - max objects constant ?
 	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_CERT_X509, objs, 32);
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_CERT_X509): %d\n", r);
 	if (r >= 0) {
@@ -484,8 +483,8 @@ void OpenSCToken::populate()
 	}
 
 	// Locate private keys
-	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_PRKEY_RSA, objs, 32);
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_PRKEY_RSA): %d\n", r);
+	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_PRKEY, objs, 32);
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(TYPE_PRKEY): %d\n", r);
 	if (r >= 0) {
 		
 		// Count the occurences of the private key ids

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -152,14 +152,14 @@ const unsigned char *newPin, size_t newPinLength )
 uint32_t OpenSCToken::pinStatus(int pinNum)
 {
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::pinStatus for pinNum (%d)\n", pinNum);
-
+        
 	if (pinNum == mCurrentPIN && !isLocked()) {
 		sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::pinStatus Verified");
 		return 0x9000;
 	}
    	else {
 		sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::pinStatus blocked");
-		return 0x6300;
+                return 0x6300; // perhaps we should also pass to caller how many retries left
 	}
 }
 
@@ -167,8 +167,14 @@ uint32_t OpenSCToken::pinStatus(int pinNum)
 // does the token look as 'locked' for keychain ?
 bool OpenSCToken::isLocked()
 {
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::isLocked()\n");
-	return mLocked;
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::isLocked() mLocked=%d\n", mLocked);
+        // enforce token state verification ("nudge" the card)
+        int logged_in = 0;
+        int rc = sc_pkcs15_check_state(mScP15Card, &logged_in, 0);
+        sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
+                 " sc_pkcs15_check_state() returned %d (logged_in=%d)", rc, logged_in);
+        
+        return mLocked;
 }
 
 

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -173,7 +173,7 @@ uint32_t OpenSCToken::pinStatus(int pinNum)
 // does the token look as 'locked' for keychain ?
 bool OpenSCToken::isLocked()
 {
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::isLocked() mLocked=%b\n", mLocked);
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::isLocked() mLocked=%s\n", (mLocked?"true":"false"));
         
         return mLocked;
 }

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -177,7 +177,7 @@ void OpenSCToken::verifyPIN(int pinNum, const uint8_t *pin, size_t pinLength)
                        sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "Warning: the reader keypad is not used; PIN entered on keyboard.");
                }
         };
-	
+
 	if (mCurrentPIN != -1) {
 		pNumber = mCurrentPIN;
 		mCurrentPIN = -1;

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -157,6 +157,7 @@ void OpenSCToken::verifyPIN(int pinNum, const uint8_t *pin, size_t pinLength)
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::verifyPIN(%d)\n", pinNum);
 	int pNumber = pinNum;
 
+
         // If the user entered no PIN in the (OS) provided prompt; pinLength is
         // zero; but *pin points to the empty string; rather than being NULL.
         //

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -111,47 +111,16 @@ const unsigned char *newPin, size_t newPinLength)
 
 }
 
-
-bool OpenSCToken:: _changePIN( int pinNum,
-const unsigned char *oldPin, size_t oldPinLength,
-const unsigned char *newPin, size_t newPinLength )
-{
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::_changePIN(), PIN num is: %d\n", pinNum);
-
-	int r, i, rv;
-	struct sc_pkcs15_object *objs[32];
-
-	// pinNum -> AuthID
-	const sc_pkcs15_id_t *auth_id = getIdFromPinMap(pinNum);
-	if (auth_id == NULL) {
-		sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  ERR: getIdFromPinMap(): no AuthID found for pinNum %d\n", pinNum);
-		CssmError::throwMe(CSSM_ERRCODE_INVALID_DATA);
-	}
-
-	// AuthID -> pin object  +  change pin
-	r = sc_pkcs15_get_objects(mScP15Card, SC_PKCS15_TYPE_AUTH_PIN, objs, 32);
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  sc_pkcs15_get_objects(pin_id=%s): %d\n", sc_pkcs15_print_id(auth_id),  r);
-	if (r >= 0) {
-		for (i = 0; i < r; i++) {
-			sc_pkcs15_auth_info_t *auth_info = (sc_pkcs15_auth_info_t *) objs[i]->data;
-			if (sc_pkcs15_compare_id(auth_id, &auth_info->auth_id)) {
-
-				rv = sc_pkcs15_change_pin( mScP15Card, objs[i], oldPin, oldPinLength, newPin, newPinLength );
-				sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "  In OpenSCToken::sc_pkcs15_change_pin returned %d for pin %d\n", rv, pinNum );
-				if (rv==0)
-					return true;
-				else
-					return false;
-			}
-		}
-	}
-	return false;
-}
-
-
 uint32_t OpenSCToken::pinStatus(int pinNum)
 {
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::pinStatus for pinNum (%d)\n", pinNum);
+        
+        // enforce token state verification ("nudge" the card)
+        int logged_in = 0;
+        int rc = sc_pkcs15_check_state(mScP15Card, &logged_in, 0);
+        sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
+                 " sc_pkcs15_check_state() returned %d (logged_in=%d)", rc, logged_in);
+        
         
 	if (pinNum == mCurrentPIN && !isLocked()) {
 		sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::pinStatus Verified");
@@ -167,12 +136,7 @@ uint32_t OpenSCToken::pinStatus(int pinNum)
 // does the token look as 'locked' for keychain ?
 bool OpenSCToken::isLocked()
 {
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::isLocked() mLocked=%d\n", mLocked);
-        // enforce token state verification ("nudge" the card)
-        int logged_in = 0;
-        int rc = sc_pkcs15_check_state(mScP15Card, &logged_in, 0);
-        sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
-                 " sc_pkcs15_check_state() returned %d (logged_in=%d)", rc, logged_in);
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::isLocked() mLocked=%b\n", mLocked);
         
         return mLocked;
 }
@@ -180,16 +144,18 @@ bool OpenSCToken::isLocked()
 
 void OpenSCToken::verifyPIN(int pinNum, const uint8_t *pin, size_t pinLength)
 {
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::verifyPIN(%d)\n", pinNum);
-	int pNumber = pinNum;
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
+                 "In OpenSCToken::verifyPIN(%d) mCurrentPIN=%d\n", pinNum, mCurrentPIN);
+        int pNumber = (mCurrentPIN != -1)? mCurrentPIN : pinNum;
 
 	// First try to ascertain what state the token is in. That somehow also
-	// nudges the token into a recognizable state...
-	int logged_in = 0;
-	int rc = sc_pkcs15_check_state(mScP15Card, &logged_in, 0);
-	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
-		 " sc_pkcs15_check_state() returned %d (logged_in=%d)", rc, logged_in);
-	
+        // nudges the token into a recognizable state...
+        int logged_in = 0;
+        int rc = sc_pkcs15_check_state(mScP15Card, &logged_in, 0);
+        sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
+                 " sc_pkcs15_check_state() returned %d (logged_in=%d)", rc, logged_in);
+        
+        
         // If the user entered no PIN in the (OS) provided prompt; pinLength is
         // zero; but *pin points to the empty string; rather than being NULL.
         //

--- a/OpenSC/OpenSCToken.cpp
+++ b/OpenSC/OpenSCToken.cpp
@@ -157,7 +157,13 @@ void OpenSCToken::verifyPIN(int pinNum, const uint8_t *pin, size_t pinLength)
 	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL, "In OpenSCToken::verifyPIN(%d)\n", pinNum);
 	int pNumber = pinNum;
 
-
+	// First try to ascertain what state the token is in. That somehow also
+	// nudges the token into a recognizable state...
+	int logged_in = 0;
+	int rc = sc_pkcs15_check_state(mScP15Card, &logged_in, 0);
+	sc_debug(mScCtx, SC_LOG_DEBUG_NORMAL,
+		 " sc_pkcs15_check_state() returned %d (logged_in=%d)", rc, logged_in);
+	
         // If the user entered no PIN in the (OS) provided prompt; pinLength is
         // zero; but *pin points to the empty string; rather than being NULL.
         //

--- a/README-this-fork.md
+++ b/README-this-fork.md
@@ -1,0 +1,8 @@
+### OpenSC.tokend supporting RSA and ECC tokens, with SHA-2 support
+This Tokend fork provides:
+* Full support of RSA tokens - signing and decrypting, including use of SHA-2 family
+* Support of ECC tokens - signing, including use of SHA-2 family (no ECDH yet)
+
+As far as we know, it provides support for all RSA and ECC PIV tokens, to the full extent of the applications' ability to use them.
+
+One remaining problem we're aware of - support for ECC key derivation on the token - has not been addressed yet, mainly because there is no application that we know of that can use ECDH, and that we could test against. I'm planning to add ECDH support in the (near?) future, but again - the likelihood of it being useful is low, because there's nothing that can use it, as far as we know.

--- a/README-this-fork.md
+++ b/README-this-fork.md
@@ -1,8 +1,8 @@
-### OpenSC.tokend supporting RSA and ECC tokens, with SHA-2 support
+### OpenSC.tokend supporting PIV (and CAC) RSA and ECC tokens, with SHA-2 support
 This Tokend fork provides:
-* Full support of RSA tokens - signing and decrypting, including use of SHA-2 family
-* Support of ECC tokens - signing, including use of SHA-2 family (no ECDH yet)
+* Full support of RSA tokens - signing and decrypting, including use of SHA-2 family hash-functions
+* Support of ECC tokens - signing, including use of SHA-2 family (but no ECDH yet)
 
-As far as we know, it provides support for all RSA and ECC PIV tokens, to the full extent of the applications' ability to use them.
+As far as we know, it provides support for all RSA and ECC PIV tokens, to the full extent of the applications' ability to use them. It has been extensively tested and shown working with (in no particular order) Google Chrome, Safari, Apple Mail, Adobe Acrobat, Keychain Access.
 
-One remaining problem we're aware of - support for ECC key derivation on the token - has not been addressed yet, mainly because there is no application that we know of that can use ECDH, and that we could test against. I'm planning to add ECDH support in the (near?) future, but again - the likelihood of it being useful is low, because there's nothing that can use it, as far as we know.
+One remaining problem we're aware of - support for ECC key derivation on the token - has not been addressed yet, mainly because there is no application that we know of that can use ECDH, and that we could test against. I'm planning to add ECDH support in the (near?) future, but again - the likelihood of it being useful is low, because there's nothing that can use it, as far as we know. Not to mention that I've no idea how to test it (aka - against what? as there is no application that uses it).

--- a/README-this-fork.md
+++ b/README-this-fork.md
@@ -5,4 +5,6 @@ This Tokend fork provides:
 
 As far as we know, it provides support for all RSA and ECC PIV tokens, to the full extent of the applications' ability to use them. It has been extensively tested and shown working with (in no particular order) Google Chrome, Safari, Apple Mail, Adobe Acrobat, Keychain Access.
 
+Tokens tested with (100% working): Yubikey NEO, Yubikey 4, US DoD CAC.
+
 One remaining problem we're aware of - support for ECC key derivation on the token - has not been addressed yet, mainly because there is no application that we know of that can use ECDH, and that we could test against. I'm planning to add ECDH support in the (near?) future, but again - the likelihood of it being useful is low, because there's nothing that can use it, as far as we know. Not to mention that I've no idea how to test it (aka - against what? as there is no application that uses it).

--- a/Tokend.xcodeproj/project.pbxproj
+++ b/Tokend.xcodeproj/project.pbxproj
@@ -703,9 +703,17 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)";
 				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)";
 				ENABLE_TESTABILITY = YES;
+				"HEADER_SEARCH_PATHS[arch=*]" = /opt/local/include;
+				"LIBRARY_SEARCH_PATHS[arch=*]" = /opt/local/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				ONLY_ACTIVE_ARCH = YES;
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-L/opt/local/lib",
+					"-lssl",
+					"-lcrypto",
+				);
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
+				"USER_HEADER_SEARCH_PATHS[arch=*]" = /opt/local/include;
 			};
 			name = Development;
 		};
@@ -715,8 +723,16 @@
 				CLANG_CXX_LIBRARY = "libstdc++";
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)";
 				CONFIGURATION_TEMP_DIR = "$(PROJECT_TEMP_DIR)";
+				"HEADER_SEARCH_PATHS[arch=*]" = /opt/local/include;
+				"LIBRARY_SEARCH_PATHS[arch=*]" = /opt/local/lib;
 				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-L/opt/local/lib",
+					"-lssl",
+					"-lcrypto",
+				);
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
+				"USER_HEADER_SEARCH_PATHS[arch=*]" = /opt/local/include;
 			};
 			name = Deployment;
 		};


### PR DESCRIPTION
This PR provides:

Improved support for PIV tokens, which was completely broken until @frankmorgner fixed it and updated his fork.
Complete support for SHA-2, which does not work in other forks (as far as I was able to test).
Support for ECDSA.
Base code for ECDH: decrypt() now calls sc_pkcs15_derive(), but ECDH is not supported yet, and not been tested because there is no application that I know of that uses it. Would be happy to re-open this issue, and improve/fix the ECDH processing.
RSA is fully supported, and has been tested with Keychain Access, Apple Mail on Yosemite and El Capitan, MS Outlook 2011 (Yosemite and El Capitan). Both interoperated with Thunderbird (same platforms - but Thunderbird does not use tokend). Also, interoperated with Blackberry Classic (a different S/MIME implementation, and a good validation test).

ECDSA was tested with Apple Mail against Thunderbird. MS Outlook 2011 could validate ECDSA signatures, but could not produce them (deficiency of the Outlook itself - it keeps asking for RSA-based signature algorithms even when the provided key is ECC).